### PR TITLE
fix: add script to hide buggy error messages

### DIFF
--- a/sessions/react-component-testing/demo-end/jest.setup.js
+++ b/sessions/react-component-testing/demo-end/jest.setup.js
@@ -3,3 +3,25 @@
 
 // Learn more: https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom/extend-expect";
+
+// Quick fix: Hiding Buggy Error Message
+beforeAll(() => {
+  jest.spyOn(console, "error").mockImplementation((msg, ...args) => {
+    // Only suppress the specific "act" warning message
+    if (
+      typeof msg === "string" &&
+      msg.includes("Warning: An update to") &&
+      msg.includes("inside a test was not wrapped in act")
+    ) {
+      return;
+    }
+
+    // Otherwise, preserve default behaviour
+    // (You could call the original console.error, or console.warn, or do nothing)
+    console.error(msg, ...args);
+  });
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
+});

--- a/sessions/react-component-testing/demo-start/jest.setup.js
+++ b/sessions/react-component-testing/demo-start/jest.setup.js
@@ -3,3 +3,25 @@
 
 // Learn more: https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom/extend-expect";
+
+// Quick fix: Hiding Buggy Error Message
+beforeAll(() => {
+  jest.spyOn(console, "error").mockImplementation((msg, ...args) => {
+    // Only suppress the specific "act" warning message
+    if (
+      typeof msg === "string" &&
+      msg.includes("Warning: An update to") &&
+      msg.includes("inside a test was not wrapped in act")
+    ) {
+      return;
+    }
+
+    // Otherwise, preserve default behaviour
+    // (You could call the original console.error, or console.warn, or do nothing)
+    console.error(msg, ...args);
+  });
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
+});

--- a/sessions/react-component-testing/lotr-app-testing/jest.setup.js
+++ b/sessions/react-component-testing/lotr-app-testing/jest.setup.js
@@ -3,3 +3,25 @@
 
 // Learn more: https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom/extend-expect";
+
+// Quick fix: Hiding Buggy Error Message
+beforeAll(() => {
+  jest.spyOn(console, "error").mockImplementation((msg, ...args) => {
+    // Only suppress the specific "act" warning message
+    if (
+      typeof msg === "string" &&
+      msg.includes("Warning: An update to") &&
+      msg.includes("inside a test was not wrapped in act")
+    ) {
+      return;
+    }
+
+    // Otherwise, preserve default behaviour
+    // (You could call the original console.error, or console.warn, or do nothing)
+    console.error(msg, ...args);
+  });
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
+});

--- a/sessions/react-component-testing/scorekeeper/jest.setup.js
+++ b/sessions/react-component-testing/scorekeeper/jest.setup.js
@@ -3,3 +3,25 @@
 
 // Learn more: https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom/extend-expect";
+
+// Quick fix: Hiding Buggy Error Message
+beforeAll(() => {
+  jest.spyOn(console, "error").mockImplementation((msg, ...args) => {
+    // Only suppress the specific "act" warning message
+    if (
+      typeof msg === "string" &&
+      msg.includes("Warning: An update to") &&
+      msg.includes("inside a test was not wrapped in act")
+    ) {
+      return;
+    }
+
+    // Otherwise, preserve default behaviour
+    // (You could call the original console.error, or console.warn, or do nothing)
+    console.error(msg, ...args);
+  });
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
+});

--- a/sessions/react-component-testing/scorekeeper_solution/jest.setup.js
+++ b/sessions/react-component-testing/scorekeeper_solution/jest.setup.js
@@ -3,3 +3,25 @@
 
 // Learn more: https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom/extend-expect";
+
+// Quick fix: Hiding Buggy Error Message
+beforeAll(() => {
+  jest.spyOn(console, "error").mockImplementation((msg, ...args) => {
+    // Only suppress the specific "act" warning message
+    if (
+      typeof msg === "string" &&
+      msg.includes("Warning: An update to") &&
+      msg.includes("inside a test was not wrapped in act")
+    ) {
+      return;
+    }
+
+    // Otherwise, preserve default behaviour
+    // (You could call the original console.error, or console.warn, or do nothing)
+    console.error(msg, ...args);
+  });
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
+});


### PR DESCRIPTION
Added a script to the `jest.setup.js` to hide the wrong messages regarding the `not wrapped in act(...)` error. 
This is not a permanent solution (hopefully) but improves the session flow substantially. 

The script was tested with the demo code as well as the challenge solution.