### PR TITLE
add user story issue template to next template project

### DIFF
--- a/templates/next/.github/ISSUE_TEMPLATE/new-user.story.md
+++ b/templates/next/.github/ISSUE_TEMPLATE/new-user.story.md
@@ -1,0 +1,28 @@
+---
+name: New User Story
+about: Create a new user story
+title: ""
+labels: ""
+assignees: ""
+---
+
+## Value proposition
+
+As a <user/role>
+I want to <feature/goal>
+In order to <benefit/purpose>
+
+## Description
+
+- Scribble / design or text
+- Precise, no unnecessary information
+
+## Acceptance criteria
+
+- [ ] What happens when an entry is empty?
+- [ ] How should something behave?
+- [ ] What is the text of an alert?
+
+## Tasks
+
+- [ ] List the tasks that need to be performed within the dev team


### PR DESCRIPTION
By Providing this template file students don't need to add it manually to their repository via the settings/new issue template workflow.